### PR TITLE
배경색 및 현재 날짜 아래 회색선 추가

### DIFF
--- a/src/components/BackGround.jsx
+++ b/src/components/BackGround.jsx
@@ -18,10 +18,12 @@ const Container = styled.div`
   display: flex;
   align-items:center;
   padding: 2rem;
+  border-bottom: 1px solid ${({ theme }) => theme.colors.gray02};
 `;
 const ArrowImage = styled.img`
   width: 1rem;
   height: 1rem;
+  margin-right: 8px;
 `;
 const DateText = styled.a`
   color: ${({ theme }) => theme.colors.gray03};

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -16,11 +16,18 @@ export default function Layout({ children }) {
 }
 const Container = styled.div`
   display: flex;
+  justify-content: center;
+  background-color: ${({ theme }) => theme.colors.gray00};
+  min-height: 100vh;
 `;
 const SubContainer = styled.div`
   display: flex;
   flex-direction: column;
   width: 100%;
+  max-width: 1440px;
+  height: 1024px;
+  box-shawdow: 0 4px 10px rgba(0, 0, 0, 0.1);
+  background-color: ${({ theme }) => theme.colors.gray00};
 `;
 
 const Sub = styled.div`


### PR DESCRIPTION

<img width="1109" alt="스크린샷 2024-11-08 오후 10 13 38" src="https://github.com/user-attachments/assets/f3a9e010-6ec3-4eb7-aab7-97b6de023ba7">


**구현 내용**

1. (로그인 페이지 제외) 모든 페이지에서 사용될 배경 구현
2. (로그인 페이지 제외) 모든 페이지에서 사용될 현재 날짜 아래 회색선 구현

